### PR TITLE
fix: ensure edit distance uses string sequences

### DIFF
--- a/AptaClux/3-train.py
+++ b/AptaClux/3-train.py
@@ -21,7 +21,7 @@ from sklearn.manifold import TSNE
 import seaborn as sns
 
 # Local application imports
-from utility import compute_edit_distance #, onehot_to_seq , onehot_to_2d(have been processed in 2-NGS_preprocessing.py)
+from utility import compute_edit_distance, onehot_to_seq, onehot_to_2d
 
 # Set global seed for reproducibility
 SEED = 42
@@ -168,17 +168,23 @@ def test(epoch, model, test_loader, device):
             original_2d = (comparison[0][0].detach().cpu().numpy()[SEQ_LENGTH:])
             reconstructed_seq = (comparison[1][0].detach().cpu().numpy()[:SEQ_LENGTH])
             reconstructed_2d = (comparison[1][0].detach().cpu().numpy()[SEQ_LENGTH:])
-            
-            # Compute the Edit distance
-            total_seq_edit_distance += compute_edit_distance(original_seq, reconstructed_seq)
-            total_2d_edit_distance += compute_edit_distance(original_2d, reconstructed_2d)
+
+            # Convert one-hot encodings to string representations
+            original_seq_str = onehot_to_seq(original_seq)
+            reconstructed_seq_str = onehot_to_seq(reconstructed_seq)
+            original_2d_str = onehot_to_2d(original_2d)
+            reconstructed_2d_str = onehot_to_2d(reconstructed_2d)
+
+            # Compute the Edit distance on strings
+            total_seq_edit_distance += compute_edit_distance(original_seq_str, reconstructed_seq_str)
+            total_2d_edit_distance += compute_edit_distance(original_2d_str, reconstructed_2d_str)
             total_seqs += 1
             print('-' * 89)
             print(f'SAMPLE {i+1}')
-            print(f"Original sequence: {original_seq}")
-            print(f"Reconstructed sequence: {reconstructed_seq}")
-            print(f"Original 2D structure: {original_2d}")
-            print(f"Reconstructed 2D structure: {reconstructed_2d}")
+            print(f"Original sequence: {original_seq_str}")
+            print(f"Reconstructed sequence: {reconstructed_seq_str}")
+            print(f"Original 2D structure: {original_2d_str}")
+            print(f"Reconstructed 2D structure: {reconstructed_2d_str}")
             
     avg_test_loss = test_loss / len(test_loader.dataset)
     avg_seq_edit_distance = total_seq_edit_distance / total_seqs

--- a/AptaClux/utility.py
+++ b/AptaClux/utility.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 import os
 from sklearn.manifold import TSNE
 
-__all__ = ['compute_edit_distance', 'onehot_to_seq', 'decode_class', 'plot_t_sne']
+__all__ = ['compute_edit_distance', 'onehot_to_seq', 'onehot_to_2d', 'decode_class', 'plot_t_sne']
 
 def compute_edit_distance(seq1, seq2):
     """
@@ -21,16 +21,29 @@ def write_to_fasta(sequences, output_path):
     print(f"FASTA file written to {output_path}")
 
 def onehot_to_seq(onehot_seq):
+    """Decode a flattened one-hot encoded sequence into a string."""
     bases = ['A', 'T', 'C', 'G']
     seq = ''
-    for i in range(0, len(onehot_seq), 6):      # as we flatten the vector, hence every 5 samples is a base
+    for i in range(0, len(onehot_seq), 4):
         try:
-            #print(len(onehot_seq))
-            seq += bases[np.argmax(onehot_seq[i:i+6])]
+            seq += bases[np.argmax(onehot_seq[i:i + 4])]
         except IndexError:
             print(f"Error at index {i} with onehot_seq length {len(onehot_seq)}")
             break
     return seq
+
+
+def onehot_to_2d(onehot_2d):
+    """Decode a flattened one-hot encoded 2D structure into dot-bracket notation."""
+    bases = ['.', '(', ')']
+    seq_2d = ''
+    for i in range(0, len(onehot_2d), 3):
+        try:
+            seq_2d += bases[np.argmax(onehot_2d[i:i + 3])]
+        except IndexError:
+            print(f"Error at index {i} with onehot_2d length {len(onehot_2d)}")
+            break
+    return seq_2d
 
 # def decode_class(onehot_class):
 #     """Decode a one-hot encoded class back to its original class."""


### PR DESCRIPTION
## Summary
- import onehot converters and decode sequences before computing edit distance
- add onehot_to_2d utility and refine onehot_to_seq

## Testing
- `python -m py_compile AptaClux/3-train.py`
- `python -m py_compile AptaClux/utility.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7e58f9448832eab400550b7102548