### PR TITLE
fix: correct wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ AptaVAE is designed as the first part of the DL-SELEX approach, which generates 
 
 ## AptaClux
 
-AptaClux as the second part of the DL-SELEX approach, can be accessed via our online web server at http://hsingapp.ust.hk. To deploy the model locally for own used, detailed procedure can be found in the README file under the AptaClux directory.
+AptaClux as the second part of the DL-SELEX approach, can be accessed via our online web server at http://hsingapp.ust.hk. To deploy the model locally for own use, detailed procedure can be found in the README file under the AptaClux directory.
 
 ## Figures
 


### PR DESCRIPTION
## Summary
- fix typo in documentation for deploying AptaClux locally

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7e58c95e0832e932923d5782b4325